### PR TITLE
Fix auto complete card cancel logic.

### DIFF
--- a/src/main/java/lu/kolja/expandedae/mixin/compat/appflux/MixinPatternProviderLogicAppFlux.java
+++ b/src/main/java/lu/kolja/expandedae/mixin/compat/appflux/MixinPatternProviderLogicAppFlux.java
@@ -103,10 +103,12 @@ public abstract class MixinPatternProviderLogicAppFlux implements IUpgradeableOb
 
     @Inject(
             method = "pushPattern",
-            at = @At("HEAD")
+            at = @At("RETURN")
     )
     private void expandedae$onPushPatternSuccess(IPatternDetails patternDetails, KeyCounter[] inputHolder, CallbackInfoReturnable<Boolean> cir) {
-        expandedae$tryAutoCompleteCraft(patternDetails);
+        if (cir.getReturnValue()) {
+            expandedae$tryAutoCompleteCraft(patternDetails);
+        }
     }
 
     @Unique

--- a/src/main/java/lu/kolja/expandedae/mixin/patternprovider/MixinPatternProviderLogic.java
+++ b/src/main/java/lu/kolja/expandedae/mixin/patternprovider/MixinPatternProviderLogic.java
@@ -166,10 +166,12 @@ public abstract class MixinPatternProviderLogic implements IUpgradeableObject, I
 
     @Inject(
             method = "pushPattern",
-            at = @At("HEAD")
+            at = @At("RETURN")
     )
     private void expandedae$onPushPatternSuccess(IPatternDetails patternDetails, KeyCounter[] inputHolder, CallbackInfoReturnable<Boolean> cir) {
-        expandedae$tryAutoCompleteCraft(patternDetails);
+        if (cir.getReturnValue()) {
+            expandedae$tryAutoCompleteCraft(patternDetails);
+        }
     }
 
     @Unique


### PR DESCRIPTION
Potential fix for #76. Makes the cancel logic mix in after the pattern push, then check and cancel only if the ingredients has really been pushed. 