### PR TITLE
Make all blocks mineable with pickaxe

### DIFF
--- a/src/generated/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
+++ b/src/generated/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
@@ -1,0 +1,29 @@
+{
+  "values": [
+    "expandedae:exp_pattern_provider",
+    "expandedae:exp_io_port",
+    "expandedae:exp_energy_cell",
+    "expandedae:giga_pattern_provider",
+    "expandedae:exp_crafting_unit",
+    "expandedae:exp_crafting_accelerator_2",
+    "expandedae:exp_crafting_accelerator_4",
+    "expandedae:exp_crafting_accelerator_8",
+    "expandedae:exp_crafting_accelerator_16",
+    "expandedae:exp_crafting_accelerator_32",
+    "expandedae:exp_crafting_accelerator_64",
+    "expandedae:exp_crafting_accelerator_128",
+    "expandedae:exp_crafting_accelerator_256",
+    "expandedae:exp_crafting_accelerator_512",
+    "expandedae:exp_crafting_accelerator_1k",
+    "expandedae:exp_crafting_accelerator_2k",
+    "expandedae:exp_crafting_accelerator_4k",
+    "expandedae:exp_crafting_accelerator_8k",
+    "expandedae:exp_crafting_accelerator_16k",
+    "expandedae:exp_crafting_accelerator_32k",
+    "expandedae:exp_crafting_accelerator_64k",
+    "expandedae:exp_crafting_accelerator_128k",
+    "expandedae:exp_crafting_accelerator_256k",
+    "expandedae:exp_crafting_accelerator_512k",
+    "expandedae:exp_crafting_accelerator_1m"
+  ]
+}

--- a/src/main/java/lu/kolja/expandedae/datagen/ExpBlockTagsProvider.java
+++ b/src/main/java/lu/kolja/expandedae/datagen/ExpBlockTagsProvider.java
@@ -1,0 +1,25 @@
+package lu.kolja.expandedae.datagen;
+
+import lu.kolja.expandedae.Expandedae;
+import lu.kolja.expandedae.definition.ExpBlocks;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.data.PackOutput;
+import net.minecraft.tags.BlockTags;
+import net.minecraftforge.common.data.BlockTagsProvider;
+import net.minecraftforge.common.data.ExistingFileHelper;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.concurrent.CompletableFuture;
+
+public class ExpBlockTagsProvider extends BlockTagsProvider {
+
+    public ExpBlockTagsProvider(PackOutput output, CompletableFuture<HolderLookup.Provider> lookupProvider, @Nullable ExistingFileHelper existingFileHelper) {
+        super(output, lookupProvider, Expandedae.MODID, existingFileHelper);
+    }
+
+    @Override
+    protected void addTags(HolderLookup.Provider provider) {
+        var pickaxe = tag(BlockTags.MINEABLE_WITH_PICKAXE);
+        ExpBlocks.getBlocks().forEach(blockDef -> pickaxe.add(blockDef.block()));
+    }
+}

--- a/src/main/java/lu/kolja/expandedae/datagen/ExpDataGen.java
+++ b/src/main/java/lu/kolja/expandedae/datagen/ExpDataGen.java
@@ -14,10 +14,12 @@ public class ExpDataGen {
         var gen = event.getGenerator();
         var out = gen.getPackOutput();
         var existing = event.getExistingFileHelper();
+        var lookup = event.getLookupProvider();
 
         gen.addProvider(event.includeClient(), new ExpLangProvider(out));
         gen.addProvider(event.includeClient(), new ExpModelProvider(out, existing));
         gen.addProvider(event.includeClient(), new ExpItemModelProvider(out, existing));
+        gen.addProvider(event.includeServer(), new ExpBlockTagsProvider(out, lookup, existing));
         gen.addProvider(event.includeServer(), new ExpRecipeProvider(out));
         gen.addProvider(event.includeServer(), new ExpLootProvider(out));
     }


### PR DESCRIPTION
Previously, mining with a fist and with pickaxe had the same speed, unlike base AE2 where mining with a pickaxe was much faster than with a fist. This PR adds the mineable/pickaxe tag on all blocks created by this mod.